### PR TITLE
fix: copy pnpm-workspace.yaml into Docker build image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:26.3.0-slim AS builder
 
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN npm install -g pnpm && \
   pnpm install --frozen-lockfile && \
   pnpm store prune


### PR DESCRIPTION
Docker build failed because pnpm-workspace.yaml (with allowBuilds config) was not copied into the build stage, causing pnpm install --frozen-lockfile to fail with ERR_PNPM_IGNORED_BUILDS.